### PR TITLE
Chore/spotify api cleanup

### DIFF
--- a/src/app/hooks/spotify/spotify_hooks.tsx
+++ b/src/app/hooks/spotify/spotify_hooks.tsx
@@ -12,6 +12,13 @@ export async function fetchArtistAlbum(token: string) {
     return await result.json();
 }
 
+export async function fetchArtistTrack(token: string) {
+    const result = await fetch("https://api.spotify.com/v1/artists/4ePunOqQbOYoQwd1298g3Z/top-tracks?country=es", {
+        method: "GET", headers: { Authorization: `Bearer ${token}` }
+    });
+    return await result.json();
+}
+
 export async function fetchUserTracks(token: string) {
     const result = await fetch("https://api.spotify.com/v1/me/top/tracks", {
         method: "GET", headers: { Authorization: `Bearer ${token}` }

--- a/src/app/personalised-homepage/page.js
+++ b/src/app/personalised-homepage/page.js
@@ -6,40 +6,44 @@ import ItemRow from "../components/personalised-homepage-components/ItemRow";
 import ItemRowContainer from "../components/personalised-homepage-components/ItemRowContainer";
 import Bg from "../components/personalised-homepage-components/Bg";
 import { useEffect, useState } from "react";
-import { fetchArtistAlbum, fetchProfile, fetchUserPlaylists, fetchUserTracks } from "../hooks/spotify/spotify_hooks";
+import { fetchArtistAlbum, fetchProfile, fetchUserPlaylists, fetchUserTracks, fetchArtistTrack } from "../hooks/spotify/spotify_hooks";
 
 function PersonalisedHomepage() {
-    let accessToken = "";
 
+    // Access token obtained from URL window
+    let accessToken = "";
     if (typeof window !== "undefined") {
         accessToken = window.location.hash.split("&")[0].split("=")[1];
     }
 
+    // Variables containing data pulled from API
     const [profileName, setProfileName] = useState("");
     const [userImage, setUserImage] = useState("");
     const [albums, setAlbums] = useState([]);
     const [tracks, setTracks] = useState([]);
     const [playlists, setPlaylists] = useState([]);
 
+    // Pulls in placeholder data from a couple of areas of Spotify API
     useEffect(() => {
-        fetchProfile(accessToken).then((res) => setUserEmail(res.email));
-        fetchProfile(accessToken).then((res) => setProfileName(res.display_name));
-        fetchProfile(accessToken).then((res) => setUserImage(res.images?.[1]?.url));
+        fetchProfile(accessToken).then((res) => {
+            setProfileName(res.display_name);
+            setUserEmail(res.email);
+            setUserImage(res.images?.[1]?.url);
+        });
         fetchArtistAlbum(accessToken).then((res) => setAlbums(res.items));
-        fetchUserTracks(accessToken).then((res) => setTracks(res.items));
+        fetchArtistTrack(accessToken).then((res) => setTracks(res.tracks));
         fetchUserPlaylists(accessToken).then((res) => setPlaylists(res.playlists?.items));
     }, []);
 
-    // Useful data for ML / backend //
+    console.log(tracks)
 
+    // Useful data for ML / backend //
     // User top tracks is an array of users top played track IDs
     const userTopTracks = tracks?.map((track) => {
         return track.id
     })
-
     // User Email - could be used as a unique identifier to store in DB and match to personality type
     const [userEmail, setUserEmail] = useState("");
-
     console.log(userEmail)
 
     return (


### PR DESCRIPTION
Just a small piece of cleanup to improve interaction with spotify API. This will make building of player and favourites features simpler and smoother. All container should render data for you now. 

Previously it was queried whether we should change redirect to vercel page after authorisation. I am wondering whether that would be a good idea at this stage as it would cause issues when building new features on local host? 

Once this is pulled I will crack on with new features!  