### PR TITLE
Feature/develop spotify web playback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "postcss": "8.4.27",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-spotify-web-playback": "^0.14.0",
         "tailwindcss": "3.3.3",
         "typescript": "5.1.6"
       },
@@ -909,6 +910,22 @@
       "integrity": "sha512-bRTd+rKomvfdS4QDlVJ6TA/Jx1F2h/TBVO5LjvhQ7QPPHp19oPNMIum7W2CMEReq/zPxpmCeB31F9+5gl/qtvw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.2.0.tgz",
+      "integrity": "sha512-dkjEAjjsoPUthQHYENjmgd453IBWLNGqFPolcmbbyKrHrGWj3AayQz7CYGN45OljDOTaFSmyb0sWgDtzpaxWjw=="
+    },
+    "node_modules/@gilbarbara/react-range-slider": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/react-range-slider/-/react-range-slider-0.7.0.tgz",
+      "integrity": "sha512-/3DF4kxk8d2VIfn7lFN6oyPG3bSfyrePYpvIACUeCjk7VW6ekyJeMCvZjNsXvN2rzNq6zpSPp3fFjmqwUN2jlA==",
+      "dependencies": {
+        "deepmerge-ts": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3861,6 +3878,16 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
+    "node_modules/@types/spotify-api": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/spotify-api/-/spotify-api-0.0.21.tgz",
+      "integrity": "sha512-26dd63oO7sxKt48dnivb8c1hvHEtNmGWi/vesAFm55Z1NiI09ytYUyKPVY8tBMn1nNbglfGA3cGxXhlOYN6SAw=="
+    },
+    "node_modules/@types/spotify-web-playback-sdk": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@types/spotify-web-playback-sdk/-/spotify-web-playback-sdk-0.1.16.tgz",
+      "integrity": "sha512-5U/Lx9ZIZPw3i4gMJQSwwe/981GzQhFXETrqjbaZOHuw8d/I6JFQ2WHCqdqpftdSQX+9DQpStd41obI4vIu1cw=="
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -4748,6 +4775,11 @@
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.2.tgz",
       "integrity": "sha512-kJhwH5nAwb34tmyuqq/lgjEKzlFXn1U99NlnB6Ws4qVaERcRUYeYP1cBw6BJ4vxaWStAUEef4WMr7WjOCnBt8w=="
     },
+    "node_modules/colorizr": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/colorizr/-/colorizr-2.1.1.tgz",
+      "integrity": "sha512-9NWFyyVwnTBsAZMrkksb+3n1u4WGbSXEqnYh2OH69Zg5+N4mJyBMFxRkJCVoFXUzDe3URgrzMhpjWPdIh741Nw=="
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -4802,6 +4834,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -4867,6 +4919,14 @@
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.3.0.tgz",
+      "integrity": "sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==",
+      "engines": {
+        "node": ">=12.4.0"
       }
     },
     "node_modules/define-properties": {
@@ -5002,6 +5062,14 @@
       "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -5610,6 +5678,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/fast-loops": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
+      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+    },
+    "node_modules/fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -6066,6 +6144,11 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -6130,6 +6213,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
+      "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -7348,6 +7440,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7417,6 +7519,25 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nano-css": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.5.tgz",
+      "integrity": "sha512-vSB9X12bbNu4ALBu7nigJgRViZ6ja3OU7CeuiV1zMIbXOdmkLahgtPmh3GBOlDxbKY0CitqlPdOReGlBLSp+yg==",
+      "dependencies": {
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/nanoid": {
@@ -8360,6 +8481,23 @@
         }
       }
     },
+    "node_modules/react-spotify-web-playback": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-spotify-web-playback/-/react-spotify-web-playback-0.14.0.tgz",
+      "integrity": "sha512-18woEWdCvkyT4EEtYkj8ktX2S0JmjdI5uoi3ho+jU7wDuHVM5vooF7rK6o84z/7OhPAU6at1FfSBtALm+g2wzw==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.2.0",
+        "@gilbarbara/react-range-slider": "^0.7.0",
+        "@types/spotify-api": "^0.0.21",
+        "@types/spotify-web-playback-sdk": "^0.1.15",
+        "colorizr": "^2.1.1",
+        "memoize-one": "^6.0.0",
+        "nano-css": "^5.3.5"
+      },
+      "peerDependencies": {
+        "react": "17 - 18"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -8536,6 +8674,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8689,8 +8835,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8714,6 +8858,12 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -8728,6 +8878,14 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -8748,6 +8906,38 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
       }
     },
     "node_modules/streamsearch": {
@@ -8915,6 +9105,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
+      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/sucrase": {
       "version": "3.34.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "postcss": "8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-spotify-web-playback": "^0.14.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.1.6"
   },

--- a/src/app/components/personalised-homepage-components/ItemCard.js
+++ b/src/app/components/personalised-homepage-components/ItemCard.js
@@ -1,17 +1,17 @@
-import Link from "next/link";
-import Image from "next/image";
-import { ReactNode } from "react"
+'use client'
+import { ReactNode } from "react";
 
-function ItemCard({ children, title, img }: { children?: ReactNode, title?: String, img?: string }) {
+function ItemCard({ children, title, img, trackID, setPlaybackID }) {
+
     return (
-        <Link className="hover:bg-gray-700 delay-50 duration-100 bg-ablack p-5 rounded-lg min-w-[10vw] group p-2 m-2" href="">
+        <div className="hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-700 delay-50 duration-100 bg-ablack p-5 rounded-lg min-w-[10vw] group p-2 m-2" id={trackID} onClick={setPlaybackID}>
             <img src={img}
                 className="w-fulls rounded shadow"
                 alt="Personality Homepage Image">
             </img>
             <h3 className="text-gray-200 font-bold mt-5 text-center">{title}</h3>
             <p className="text-gray-400 font-light mt-2 text-xs text-center">{children}</p>
-        </Link>
+        </div>
     )
 }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,7 +7,7 @@ import SpotifyLogo from "../../../public/images/spotify_logo.png"
 import SpotifyLogo2 from "../../../public/images/Spotify_Logo_2.png"
 import Link from "next/link";
 
-const AUTH_URL = "https://accounts.spotify.com/en/authorize?response_type=token&client_id=a96eef12a4ff426fa590bc684129730c&scope=ugc-image-upload%20playlist-modify-private%20playlist-modify-public%20streaming%20user-read-email%20user-top-read&redirect_uri=http://localhost:3000/personalised-homepage"
+const AUTH_URL = "https://accounts.spotify.com/en/authorize?response_type=token&client_id=a96eef12a4ff426fa590bc684129730c&scope=ugc-image-upload%20playlist-modify-private%20playlist-modify-public%20streaming%20user-read-email%20user-top-read%20user-read-playback-state%20user-modify-playback-state%20user-read-currently-playing%20app-remote-control%20user-read-playback-position%20user-read-private&redirect_uri=http://localhost:3000/personalised-homepage"
 
 function Login() {
     return (

--- a/src/app/personalised-homepage/page.js
+++ b/src/app/personalised-homepage/page.js
@@ -1,12 +1,13 @@
 'use client'
 import Aside from "../components/personalised-homepage-components/Aside";
-import ItemCard from "../components/personalised-homepage-components/ItemCard";
 import ItemContainer from "../components/personalised-homepage-components/ItemContainer";
 import ItemRow from "../components/personalised-homepage-components/ItemRow";
 import ItemRowContainer from "../components/personalised-homepage-components/ItemRowContainer";
 import Bg from "../components/personalised-homepage-components/Bg";
 import { useEffect, useState } from "react";
 import { fetchArtistAlbum, fetchProfile, fetchUserPlaylists, fetchUserTracks, fetchArtistTrack } from "../hooks/spotify/spotify_hooks";
+import SpotifyPlayer from 'react-spotify-web-playback';
+import ItemCard from "../components/personalised-homepage-components/ItemCard";
 
 function PersonalisedHomepage() {
 
@@ -22,6 +23,12 @@ function PersonalisedHomepage() {
     const [albums, setAlbums] = useState([]);
     const [tracks, setTracks] = useState([]);
     const [playlists, setPlaylists] = useState([]);
+    const [userTopArray, setUserTopArray] = useState([]);
+
+    // Variables / state used to control playback
+    const [playTrack, setPlayTrack] = useState("");
+    const [playerType, setPlayerType] = useState("");
+    const [playback, setPlayback] = useState(false);
 
     // Pulls in placeholder data from a couple of areas of Spotify API
     useEffect(() => {
@@ -30,21 +37,43 @@ function PersonalisedHomepage() {
             setUserEmail(res.email);
             setUserImage(res.images?.[1]?.url);
         });
+        fetchUserTracks(accessToken).then((res) => setUserTopArray(res.items))
         fetchArtistAlbum(accessToken).then((res) => setAlbums(res.items));
         fetchArtistTrack(accessToken).then((res) => setTracks(res.tracks));
         fetchUserPlaylists(accessToken).then((res) => setPlaylists(res.playlists?.items));
     }, []);
 
-    console.log(tracks)
-
     // Useful data for ML / backend //
     // User top tracks is an array of users top played track IDs
-    const userTopTracks = tracks?.map((track) => {
+    const userTopTracks = userTopArray?.map((track) => {
         return track.id
     })
+
+    console.log(userTopTracks);
     // User Email - could be used as a unique identifier to store in DB and match to personality type
     const [userEmail, setUserEmail] = useState("");
     console.log(userEmail)
+
+
+    // Below functions play tracks / albums / playlists on click
+
+    function setTrackId(e) {
+        setPlayTrack(e.currentTarget.id);
+        setPlayerType("track");
+        setPlayback(true);
+    }
+
+    function setAlbumId(e) {
+        setPlayTrack(e.currentTarget.id);
+        setPlayerType("album");
+        setPlayback(true);
+    }
+
+    function setPlaylistId(e) {
+        setPlayTrack(e.currentTarget.id);
+        setPlayerType("playlist");
+        setPlayback(true);
+    }
 
     return (
         <Bg>
@@ -54,22 +83,30 @@ function PersonalisedHomepage() {
                 <ItemRowContainer>
                     <ItemRow title="Recommended Songs">
                         {tracks?.map((track, index) => {
-                            return <ItemCard key={`song${index}`} title={track.name} img={track.album.images[1].url}>{track.artists[0].name}</ItemCard>
+                            return <ItemCard key={`song${index}`} trackID={track.id} title={track.name} img={track.album.images[1].url} setPlaybackID={setTrackId}>{track.artists[0].name}</ItemCard>
                         })}
                     </ItemRow>
                     <ItemRow title="Recommended Albums">
                         {albums?.map((album, index) => {
-                            return <ItemCard key={`album${index}`} title={album.name} img={album.images[1].url}>{album.artists[0].name}</ItemCard>
+                            return <ItemCard key={`album${index}`} trackID={album.id} title={album.name} img={album.images[1].url} setPlaybackID={setAlbumId}>{album.artists[0].name}</ItemCard>
                         })}
                     </ItemRow>
                     <ItemRow title="Recommended Playlists">
                         {playlists?.map((playlist, index) => {
-                            return <ItemCard key={`playlist${index}`} title={playlist.name} img={playlist.images[0].url}>{playlist.description}</ItemCard>
+                            return <ItemCard key={`playlist${index}`} trackID={playlist.id} title={playlist.name} img={playlist.images[0].url} setPlaybackID={setPlaylistId}>{playlist.description}</ItemCard>
                         })}
                     </ItemRow>
                 </ItemRowContainer>
             </ItemContainer>
+            <div className="min-w-[100vw]">
+                <SpotifyPlayer
+                    token={accessToken}
+                    uris={[`spotify:${playerType}:${playTrack}`]}
+                    play={playback}>
+                </SpotifyPlayer>
+            </div>
         </Bg>
+
     )
 }
 


### PR DESCRIPTION
Playback should now be working when users click songs, albums and playlists. Please note:

1 - I believe that users may need a premium account to use the playback feature unfortunately, which is very annoying and I didn't see this until I started to work out how to implement the player. But, when I logged in Spotify offered me 3 months free so I took this, maybe they will do the same for you if you log in. If you have time to test please npm run i to install the player and we can find out if tracks play without premium. Also, I didn't have time to create proper tests this PR but will look to do that going forwards. 

2 - In response to the docs you sent earlier in regards to ML aspect of our project and spotify track ID, I would assume that us rendering albums and playlists recommended by personality type from the ML component will not be possible / will take some more development. In this case shall we focus on just pulling in a large number of individual tracks to the personalised homepage with the option to create a favourites playlist from these? 

3 - Unfortunately I have not been able to get some components to work via TS, this is outlined in commits. This can be implemented in another branch focused on this fix down the line. 

4 - This is more of an MVP pr for playback. There are some improvement to be made in terms of aestetics etc.
![Screenshot 2023-09-17 200916](https://github.com/JamesRobertSutcliffe/personality-music-recommender/assets/107635428/98896f07-2012-4487-a04c-e0248987877e)
