### PR TITLE
Redirect unregistered users to test page

### DIFF
--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,37 @@
+import { createUser, getUser, IUser } from "../../../db/dal/user";
+import { redirect } from "next/navigation";
+
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const params = new URLSearchParams(url.search);
+  const email = params.get("email");
+
+  if (!email) {
+    return new Response(JSON.stringify({ error: "email is required" }), {
+      status: 400,
+    });
+  }
+
+  const dbUser = await getUser(email);
+
+  return new Response(
+    JSON.stringify({
+      dbUser,
+    })
+  );
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await request.json();
+  const { email, personality_type } = body;
+  const existingUser = await getUser(email);
+
+  if (existingUser) {
+    return new Response(JSON.stringify({ error: "User already exists" }), {
+      status: 400,
+    });
+  }
+
+  const newUser = await createUser({ email, personality_type });
+  return new Response(JSON.stringify({ newUser }), { status: 200 });
+}

--- a/src/app/personalised-homepage/page.js
+++ b/src/app/personalised-homepage/page.js
@@ -1,133 +1,181 @@
-'use client'
+"use client";
 import Aside from "../components/personalised-homepage-components/Aside";
 import ItemContainer from "../components/personalised-homepage-components/ItemContainer";
 import ItemRow from "../components/personalised-homepage-components/ItemRow";
 import ItemRowContainer from "../components/personalised-homepage-components/ItemRowContainer";
 import Bg from "../components/personalised-homepage-components/Bg";
 import { useEffect, useState } from "react";
-import { fetchArtistAlbum, fetchProfile, fetchUserPlaylists, fetchUserTracks, fetchArtistTrack } from "../hooks/spotify/spotify_hooks";
-import SpotifyPlayer from 'react-spotify-web-playback';
+import {
+  fetchArtistAlbum,
+  fetchProfile,
+  fetchUserPlaylists,
+  fetchUserTracks,
+  fetchArtistTrack,
+} from "../hooks/spotify/spotify_hooks";
+import SpotifyPlayer from "react-spotify-web-playback";
 import ItemCard from "../components/personalised-homepage-components/ItemCard";
 import Loading from "../components/personalised-homepage-components/Loading";
-import {redirect} from "next/navigation";
+import { redirect } from "next/navigation";
 
 function PersonalisedHomepage() {
+  // Access token obtained from URL window
+  let accessToken = "";
+  if (typeof window !== "undefined") {
+    accessToken = window.location.hash.split("&")[0].split("=")[1];
+  }
 
-    // Access token obtained from URL window
-    let accessToken = "";
-    if (typeof window !== "undefined") {
-        accessToken = window.location.hash.split("&")[0].split("=")[1];
-    }
+  // Variables containing data pulled from API
+  const [profileName, setProfileName] = useState("");
+  const [userImage, setUserImage] = useState("");
+  const [albums, setAlbums] = useState([]);
+  const [tracks, setTracks] = useState([]);
+  const [playlists, setPlaylists] = useState([]);
+  const [userTopArray, setUserTopArray] = useState([]);
+  const [userProduct, setUserProduct] = useState();
+  const [dbUser, setDbUser] = useState();
+  const [profileLoad, setProfileLoad] = useState(false);
+  const [userEmail, setUserEmail] = useState("");
 
-    // Variables containing data pulled from API
-    const [profileName, setProfileName] = useState("");
-    const [userImage, setUserImage] = useState("");
-    const [albums, setAlbums] = useState([]);
-    const [tracks, setTracks] = useState([]);
-    const [playlists, setPlaylists] = useState([]);
-    const [userTopArray, setUserTopArray] = useState([]);
-    const [userProduct, setUserProduct] = useState();
-    const [dbUser, setDbUser] = useState();
-    const [profileLoad, setProfileLoad] = useState(false);
-    const [userEmail, setUserEmail] = useState("");
+  // Variables / state used to control playback
+  const [playTrack, setPlayTrack] = useState("");
+  const [playerType, setPlayerType] = useState("");
+  const [playback, setPlayback] = useState(false);
 
-    // Variables / state used to control playback
-    const [playTrack, setPlayTrack] = useState("");
-    const [playerType, setPlayerType] = useState("");
-    const [playback, setPlayback] = useState(false);
+  // Pulls in placeholder data from a couple of areas of Spotify API
+  useEffect(() => {
+    const fetchProfileData = async (accessToken) => {
+      const profile = await fetchProfile(accessToken);
+      setProfileName(profile.display_name);
+      setUserEmail(profile.email);
+      setUserImage(profile.images?.[1]?.url);
+      setUserProduct(profile.product);
 
-    // Pulls in placeholder data from a couple of areas of Spotify API
-    useEffect(() => {
-        const fetchProfileData = async (accessToken) => {
-        const profile = await fetchProfile(accessToken);
-            setProfileName(profile.display_name);
-            setUserEmail(profile.email);
-            setUserImage(profile.images?.[1]?.url);
-            setUserProduct(profile.product);
+      const dbUser = await fetch(`/api/user?email=${profile.email}`).then(
+        (res) => res.json()
+      );
+      setDbUser(dbUser);
 
-            const dbUser = await fetch(`/api/user?email=${profile.email}`).then(res => res.json());
-            console.log(dbUser);
-            setDbUser(dbUser);
+      setProfileLoad(true);
+    };
 
-            setProfileLoad(true);
-        };
+    fetchProfileData(accessToken);
+    fetchUserTracks(accessToken).then((res) => setUserTopArray(res.items));
+    fetchArtistAlbum(accessToken).then((res) => setAlbums(res.items));
+    fetchArtistTrack(accessToken).then((res) => setTracks(res.tracks));
+    fetchUserPlaylists(accessToken).then((res) =>
+      setPlaylists(res.playlists?.items)
+    );
+  }, [accessToken]);
 
-        fetchProfileData(accessToken);
-        fetchUserTracks(accessToken).then((res) => setUserTopArray(res.items))
-        fetchArtistAlbum(accessToken).then((res) => setAlbums(res.items));
-        fetchArtistTrack(accessToken).then((res) => setTracks(res.tracks));
-        fetchUserPlaylists(accessToken).then((res) => setPlaylists(res.playlists?.items));
-    }, [accessToken]);
+  if (dbUser && Object.keys(dbUser).length === 0) return redirect("/test-page");
+  // Below functions play tracks / albums / playlists on click
 
-    if(dbUser && Object.keys(dbUser).length === 0) return redirect('/test-page')
-    // Below functions play tracks / albums / playlists on click
+  // Useful data for ML / backend //
+  // User top tracks is an array of users top played track IDs
+  const userTopTracks = userTopArray?.map((track) => {
+    return track.id;
+  });
+  function setTrackId(e) {
+    setPlayTrack(e.currentTarget.id);
+    setPlayerType("track");
+    setPlayback(true);
+  }
 
-    // Useful data for ML / backend //
-    // User top tracks is an array of users top played track IDs
-    const userTopTracks = userTopArray?.map((track) => {
-        return track.id
-    })
-    function setTrackId(e) {
-        setPlayTrack(e.currentTarget.id);
-        setPlayerType("track");
-        setPlayback(true);
-    }
+  function setAlbumId(e) {
+    setPlayTrack(e.currentTarget.id);
+    setPlayerType("album");
+    setPlayback(true);
+  }
 
-    function setAlbumId(e) {
-        setPlayTrack(e.currentTarget.id);
-        setPlayerType("album");
-        setPlayback(true);
-    }
+  function setPlaylistId(e) {
+    setPlayTrack(e.currentTarget.id);
+    setPlayerType("playlist");
+    setPlayback(true);
+  }
 
-    function setPlaylistId(e) {
-        setPlayTrack(e.currentTarget.id);
-        setPlayerType("playlist");
-        setPlayback(true);
-    }
+  // userPremium function checks whether user product is premium
+  const userPremium = () => {
+    return userProduct === "premium";
+  };
 
+  // UserProfilePic function checks whether user
 
-    // userPremium function checks whether user product is premium
-    const userPremium = () => {
-        return userProduct === "premium"
-    }
+  const setProfilePic =
+    userImage === undefined ? "https://i.ibb.co/WHfbS7L/logo.png" : userImage;
 
-    // UserProfilePic function checks whether user 
-
-    const setProfilePic = userImage === undefined ? "https://i.ibb.co/WHfbS7L/logo.png" : userImage;
-
-    return (
-
-        <Bg>
-            {profileLoad === true ? <Aside username={profileName} personalityType="Architect" profileImage={setProfilePic}></Aside> : null}
-            {profileLoad === true ? <ItemContainer>
-                <ItemRowContainer>
-                    <ItemRow title="Recommended Songs">
-                        {tracks?.map((track, index) => {
-                            return <ItemCard key={`song${index}`} trackID={track.id} title={track.name} img={track.album.images[1].url} setPlaybackID={setTrackId}>{track.artists[0].name}</ItemCard>
-                        })}
-                    </ItemRow>
-                    <ItemRow title="Recommended Albums">
-                        {albums?.map((album, index) => {
-                            return <ItemCard key={`album${index}`} trackID={album.id} title={album.name} img={album.images[1].url} setPlaybackID={setAlbumId}>{album.artists[0].name}</ItemCard>
-                        })}
-                    </ItemRow>
-                    <ItemRow title="Recommended Playlists">
-                        {playlists?.map((playlist, index) => {
-                            return <ItemCard key={`playlist${index}`} trackID={playlist.id} title={playlist.name} img={playlist.images[0].url} setPlaybackID={setPlaylistId}>{playlist.description}</ItemCard>
-                        })}
-                    </ItemRow>
-                </ItemRowContainer>
-            </ItemContainer> : <Loading />}
-            <div className="min-w-[100vw]">
-                {userPremium() && (<SpotifyPlayer
-                    token={accessToken}
-                    uris={[`spotify:${playerType}:${playTrack}`]}
-                    play={playback}>
-                </SpotifyPlayer>)}
-            </div>
-        </Bg>
-
-    )
+  return (
+    <Bg>
+      {profileLoad === true ? (
+        <Aside
+          username={profileName}
+          personalityType="Architect"
+          profileImage={setProfilePic}
+        ></Aside>
+      ) : null}
+      {profileLoad === true ? (
+        <ItemContainer>
+          <ItemRowContainer>
+            <ItemRow title="Recommended Songs">
+              {tracks?.map((track, index) => {
+                return (
+                  <ItemCard
+                    key={`song${index}`}
+                    trackID={track.id}
+                    title={track.name}
+                    img={track.album.images[1].url}
+                    setPlaybackID={setTrackId}
+                  >
+                    {track.artists[0].name}
+                  </ItemCard>
+                );
+              })}
+            </ItemRow>
+            <ItemRow title="Recommended Albums">
+              {albums?.map((album, index) => {
+                return (
+                  <ItemCard
+                    key={`album${index}`}
+                    trackID={album.id}
+                    title={album.name}
+                    img={album.images[1].url}
+                    setPlaybackID={setAlbumId}
+                  >
+                    {album.artists[0].name}
+                  </ItemCard>
+                );
+              })}
+            </ItemRow>
+            <ItemRow title="Recommended Playlists">
+              {playlists?.map((playlist, index) => {
+                return (
+                  <ItemCard
+                    key={`playlist${index}`}
+                    trackID={playlist.id}
+                    title={playlist.name}
+                    img={playlist.images[0].url}
+                    setPlaybackID={setPlaylistId}
+                  >
+                    {playlist.description}
+                  </ItemCard>
+                );
+              })}
+            </ItemRow>
+          </ItemRowContainer>
+        </ItemContainer>
+      ) : (
+        <Loading />
+      )}
+      <div className="min-w-[100vw]">
+        {userPremium() && (
+          <SpotifyPlayer
+            token={accessToken}
+            uris={[`spotify:${playerType}:${playTrack}`]}
+            play={playback}
+          ></SpotifyPlayer>
+        )}
+      </div>
+    </Bg>
+  );
 }
 
 export default PersonalisedHomepage;

--- a/tests/api/user/route.spec.ts
+++ b/tests/api/user/route.spec.ts
@@ -1,0 +1,42 @@
+import { GET, POST } from "../../../src/app/api/user/route";
+import { createMockUser } from "../../../tests/db/dal/user.spec";
+import { query } from '../../../src/db/db';
+
+describe("GET Function", () => {
+  it("should return 400 if no email is provided", async () => {
+    const request = { url: "http://localhost" };
+    const result = await GET(request as any);
+
+    expect(result.status).toBe(400);
+  });
+
+  it("should return user details if email exists", async () => {
+    const mockUser = await createMockUser();
+    const request = { url: `http://localhost?email=${mockUser.email}` };
+
+    const result = await GET(request as any);
+    const data = JSON.parse(await result.text());
+
+    expect(data.dbUser.email).toBe(mockUser.email);
+  });
+});
+
+describe("POST Function", () => {
+  it("should create a new user if email is new", async () => {
+    const request = {
+      json: async () => ({
+        email: "new99@email.com",
+        personality_type: "newType",
+      }),
+    };
+
+    const result = await POST(request as any);
+
+    if (result) {
+      expect(result.status).toBe(200);
+    }
+
+    const data = await result.json();
+    query(`DELETE FROM users WHERE id=${data.newUser.id}`)
+  });
+});

--- a/tests/api/user/route.spec.ts
+++ b/tests/api/user/route.spec.ts
@@ -1,6 +1,6 @@
 import { GET, POST } from "../../../src/app/api/user/route";
 import { createMockUser } from "../../../tests/db/dal/user.spec";
-import { query } from '../../../src/db/db';
+import { query } from "../../../src/db/db";
 
 describe("GET Function", () => {
   it("should return 400 if no email is provided", async () => {
@@ -37,6 +37,6 @@ describe("POST Function", () => {
     }
 
     const data = await result.json();
-    query(`DELETE FROM users WHERE id=${data.newUser.id}`)
+    query(`DELETE FROM users WHERE id=${data.newUser.id}`);
   });
 });


### PR DESCRIPTION
This PR introduces a redirect to `/test-page`.

For a more seamless user experience, it may be beneficial to re-evaluate our current approach to fetching data from Spotify and managing client-side redirects. Ideally, we should fetch the necessary data and determine the appropriate route for the client before any content renders. 
Addressing this will likely require a significant investment of time, as it would involve a comprehensive refactoring of the Personalised Homepage.

The Personalised Homepage is currently configured in the Spotify app as the designated redirect route, this should probably be changed at some point. To enhance performance, we could consider directing traffic initially to a less resource-intensive page (performance metrics provided below).

**Lightouse run**
<img width="689" alt="image" src="https://github.com/JamesRobertSutcliffe/personality-music-recommender/assets/53922624/9c7876d0-110b-476e-8d0f-85b257caabab">

While there are some performance bottlenecks, mainly because of rendering relying on client-side data fetching, the changes implemented should work 👀🤞

## Testing
1. [Sign in](http://localhost:3000/login)
2. Confirm you have been redirected to `/test-page`
3. `./scripts/server.sh`
4. `npm run test`