### PR TITLE
Create user in db when personality type is selected

### DIFF
--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -12,11 +12,11 @@ export async function GET(request: Request): Promise<Response> {
     });
   }
 
-  const dbUser = await getUser(email);
+  const user = await getUser(email);
 
   return new Response(
     JSON.stringify({
-      dbUser,
+      ...user,
     })
   );
 }

--- a/src/app/components/personalised-homepage-components/Aside.tsx
+++ b/src/app/components/personalised-homepage-components/Aside.tsx
@@ -10,7 +10,7 @@ function Aside({ username, personalityType, profileImage }: { username: String, 
                         </div>
                     </div>
                     <div className="row-span-1 bg-ablack p-1 m-2 min-h-[40vh] flex justify-center items-center">
-                        <h1 className="text-xl text-center">Personality Type:{personalityType} (placeholder)</h1>
+                        <h1 className="text-xl text-center">Personality Type: {personalityType}</h1>
                     </div>
                 </div>
             </div>

--- a/src/app/personalised-homepage/page.js
+++ b/src/app/personalised-homepage/page.js
@@ -51,10 +51,10 @@ function PersonalisedHomepage() {
       setUserImage(profile.images?.[1]?.url);
       setUserProduct(profile.product);
 
-      const dbUser = await fetch(`/api/user?email=${profile.email}`).then(
+      const user = await fetch(`/api/user?email=${profile.email}`).then(
         (res) => res.json()
       );
-      setDbUser(dbUser);
+      setDbUser(user);
 
       setProfileLoad(true);
     };
@@ -109,7 +109,7 @@ function PersonalisedHomepage() {
       {profileLoad === true ? (
         <Aside
           username={profileName}
-          personalityType="Architect"
+          personalityType={dbUser.personality_type}
           profileImage={setProfilePic}
         ></Aside>
       ) : null}

--- a/src/app/test-page/page.tsx
+++ b/src/app/test-page/page.tsx
@@ -13,6 +13,7 @@ import {
   Button,
 } from "@nextui-org/react";
 import { useState, useContext } from "react";
+import { useRouter } from 'next/navigation';
 import { EmailContext } from "../context/EmailContext";
 
 const personalityTypes = [
@@ -38,6 +39,10 @@ function Testpage() {
   const { userEmail } = useContext(EmailContext);
   const [selectedType, setSelectedType] = useState({code: "", label: ""});
   const router = useRouter();
+
+  if (typeof window !== "undefined" && !userEmail) {
+    router.push('https://accounts.spotify.com/en/authorize?response_type=token&client_id=a96eef12a4ff426fa590bc684129730c&scope=ugc-image-upload%20playlist-modify-private%20playlist-modify-public%20streaming%20user-read-email%20user-top-read%20user-read-playback-state%20user-modify-playback-state%20user-read-currently-playing%20app-remote-control%20user-read-playback-position%20user-read-private&redirect_uri=http://localhost:3000/personalised-homepage')
+  }
 
   return (
     <>

--- a/src/app/test-page/page.tsx
+++ b/src/app/test-page/page.tsx
@@ -15,8 +15,28 @@ import {
 import { useContext } from "react";
 import { EmailContext } from "../context/EmailContext";
 
+const personalityTypes = [
+  { code: "INTJ", name: "Architect" },
+  { code: "INTP", name: "Logician" },
+  { code: "ENTJ", name: "Commander" },
+  { code: "ENTP", name: "Debater" },
+  { code: "INFJ", name: "Advocate" },
+  { code: "INFP", name: "Mediator" },
+  { code: "ENFJ", name: "Protagonist" },
+  { code: "ENFP", name: "Campaigner" },
+  { code: "ISTJ", name: "Logistician" },
+  { code: "ISFJ", name: "Defender" },
+  { code: "ESTJ", name: "Executive" },
+  { code: "ESFJ", name: "Consul" },
+  { code: "ISTP", name: "Virtuoso" },
+  { code: "ISFP", name: "Adventurer" },
+  { code: "ESTP", name: "Entrepreneur" },
+  { code: "ESFP", name: "Entertainer" },
+];
+
 function Testpage() {
   const { userEmail } = useContext(EmailContext);
+
   return (
     <>
       <Heading>Take the Test</Heading>
@@ -56,55 +76,12 @@ function Testpage() {
               Select Personality Type
             </Button>
           </DropdownTrigger>
-          <DropdownMenu aria-label="Static Actions">
-            <DropdownItem key="Architect" className="text-agrey">
-              INTJ - Architect
-            </DropdownItem>
-            <DropdownItem key="Logician" className="text-agrey">
-              INTP - Logician
-            </DropdownItem>
-            <DropdownItem key="Commander" className="text-agrey">
-              ENTJ - Commander
-            </DropdownItem>
-            <DropdownItem key="Debater" className="text-agrey">
-              ENTP - Debater
-            </DropdownItem>
-            <DropdownItem key="Advocate" className="text-agrey">
-              INFJ - Advocate
-            </DropdownItem>
-            <DropdownItem key="Mediator" className="text-agrey">
-              INFP - Mediator
-            </DropdownItem>
-            <DropdownItem key="Protagonist" className="text-agrey">
-              ENFJ - Protagonist
-            </DropdownItem>
-            <DropdownItem key="Campaigner" className="text-agrey">
-              ENFP - Campaigner
-            </DropdownItem>
-            <DropdownItem key="Logistician" className="text-agrey">
-              ISTJ - Logistician
-            </DropdownItem>
-            <DropdownItem key="Defender" className="text-agrey">
-              ISFJ - Defender
-            </DropdownItem>
-            <DropdownItem key="Executive" className="text-agrey">
-              ESTJ - Executive
-            </DropdownItem>
-            <DropdownItem key="Consul" className="text-agrey">
-              ESFJ - Consul
-            </DropdownItem>
-            <DropdownItem key="Virtuoso" className="text-agrey">
-              ISTP - Virtuoso
-            </DropdownItem>
-            <DropdownItem key="Adventurer" className="text-agrey">
-              ISFP - Adventurer
-            </DropdownItem>
-            <DropdownItem key="Entrepreneur" className="text-agrey">
-              ESTP - Entrepreneur
-            </DropdownItem>
-            <DropdownItem key="Entertainer" className="text-agrey">
-              ESFP - Entertainer
-            </DropdownItem>
+          <DropdownMenu aria-name="Static Actions">
+            {personalityTypes.map(({ code, name }) => (
+              <DropdownItem key={code} className="text-agrey">
+                {`${code} - ${name}`}
+              </DropdownItem>
+            ))}
           </DropdownMenu>
         </Dropdown>
       </div>

--- a/src/app/test-page/page.tsx
+++ b/src/app/test-page/page.tsx
@@ -44,6 +44,24 @@ function Testpage() {
     router.push('https://accounts.spotify.com/en/authorize?response_type=token&client_id=a96eef12a4ff426fa590bc684129730c&scope=ugc-image-upload%20playlist-modify-private%20playlist-modify-public%20streaming%20user-read-email%20user-top-read%20user-read-playback-state%20user-modify-playback-state%20user-read-currently-playing%20app-remote-control%20user-read-playback-position%20user-read-private&redirect_uri=http://localhost:3000/personalised-homepage')
   }
 
+  async function handleSave () {
+    const requestBody = {
+      email: userEmail,
+      personality_type: selectedType.code, 
+    };
+
+    const response = await fetch('/api/user', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    const newUser = await response.json();
+    router.push('/personalised-homepage');
+  }
+
   return (
     <>
       <Heading>Take the Test</Heading>

--- a/src/app/test-page/page.tsx
+++ b/src/app/test-page/page.tsx
@@ -12,7 +12,7 @@ import {
   DropdownItem,
   Button,
 } from "@nextui-org/react";
-import { useContext } from "react";
+import { useState, useContext } from "react";
 import { EmailContext } from "../context/EmailContext";
 
 const personalityTypes = [
@@ -36,6 +36,8 @@ const personalityTypes = [
 
 function Testpage() {
   const { userEmail } = useContext(EmailContext);
+  const [selectedType, setSelectedType] = useState({code: "", label: ""});
+  const router = useRouter();
 
   return (
     <>
@@ -73,17 +75,26 @@ function Testpage() {
         <Dropdown>
           <DropdownTrigger>
             <Button variant="bordered" className="text-awhite m-auto text-xl">
-              Select Personality Type
+              {selectedType.label || "Select Personality Type"}
             </Button>
           </DropdownTrigger>
           <DropdownMenu aria-name="Static Actions">
             {personalityTypes.map(({ code, name }) => (
-              <DropdownItem key={code} className="text-agrey">
+              <DropdownItem
+                key={code}
+                className="text-agrey"
+                onClick={() => setSelectedType({code, label:`${code} - ${name}`})}
+              >
                 {`${code} - ${name}`}
               </DropdownItem>
             ))}
           </DropdownMenu>
         </Dropdown>
+        {selectedType.code && (
+          <Button className="bg-ablue text-awhite text-xl m-auto mt-6" onClick={handleSave}>
+            Save
+          </Button>
+        )}
       </div>
     </>
   );

--- a/src/app/test-page/page.tsx
+++ b/src/app/test-page/page.tsx
@@ -1,66 +1,115 @@
-'use client'
+"use client";
 import Heading from "../components/Heading";
 import Subheading from "../components/Subheading";
 import Image from "next/image";
-import sixteen from "../../../public/images/16personalities.png"
+import sixteen from "../../../public/images/16personalities.png";
 import Link from "next/link";
 import Paragraph from "../components/Paragraph";
-import { Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, Button } from "@nextui-org/react";
+import {
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+  Button,
+} from "@nextui-org/react";
 import { useContext } from "react";
 import { EmailContext } from "../context/EmailContext";
 
 function Testpage() {
   const { userEmail } = useContext(EmailContext);
-    return (
-        <>
-            <Heading>
-                Take the Test
-            </Heading>
-            <Subheading className="text-agrey">
-                Find out your personality type via the 16 Personalities Website
-            </Subheading>
-            <Link href={"https://www.16personalities.com/free-personality-test"} target="blank">
-                <Image src={sixteen}
-                    className="m-auto p-2"
-                    width={1200}
-                    height={1200}
-                    alt="Sixteen Personalities Website">
-                </Image>
-            </Link>
-            <Paragraph>
-                Click on the image above to be redirected to the 16 personalities Website. Run through the test and take note of your
-                personality type code (just the first 4 letters). Select this code from the dropdown menu below to discover music based on this personality type.
-                You can learn more about different personality types <Link href={"https://www.16personalities.com/personality-types"} target="blank" style={{ textDecoration: "underline" }}>here.</Link>
-            </Paragraph>
-            <div className="flex m-2 p-2">
-                <Dropdown>
-                    <DropdownTrigger>
-                        <Button variant="bordered" className="text-awhite m-auto text-xl">
-                            Select Personality Type
-                        </Button>
-                    </DropdownTrigger>
-                    <DropdownMenu aria-label="Static Actions">
-                        <DropdownItem key="Architect" className="text-agrey">INTJ - Architect</DropdownItem>
-                        <DropdownItem key="Logician" className="text-agrey">INTP - Logician</DropdownItem>
-                        <DropdownItem key="Commander" className="text-agrey">ENTJ - Commander</DropdownItem>
-                        <DropdownItem key="Debater" className="text-agrey">ENTP - Debater</DropdownItem>
-                        <DropdownItem key="Advocate" className="text-agrey">INFJ - Advocate</DropdownItem>
-                        <DropdownItem key="Mediator" className="text-agrey">INFP - Mediator</DropdownItem>
-                        <DropdownItem key="Protagonist" className="text-agrey">ENFJ - Protagonist</DropdownItem>
-                        <DropdownItem key="Campaigner" className="text-agrey">ENFP - Campaigner</DropdownItem>
-                        <DropdownItem key="Logistician" className="text-agrey">ISTJ - Logistician</DropdownItem>
-                        <DropdownItem key="Defender" className="text-agrey">ISFJ - Defender</DropdownItem>
-                        <DropdownItem key="Executive" className="text-agrey">ESTJ - Executive</DropdownItem>
-                        <DropdownItem key="Consul" className="text-agrey">ESFJ - Consul</DropdownItem>
-                        <DropdownItem key="Virtuoso" className="text-agrey">ISTP - Virtuoso</DropdownItem>
-                        <DropdownItem key="Adventurer" className="text-agrey">ISFP - Adventurer</DropdownItem>
-                        <DropdownItem key="Entrepreneur" className="text-agrey">ESTP - Entrepreneur</DropdownItem>
-                        <DropdownItem key="Entertainer" className="text-agrey">ESFP - Entertainer</DropdownItem>
-                    </DropdownMenu>
-                </Dropdown>
-            </div>
-        </>
-    )
+  return (
+    <>
+      <Heading>Take the Test</Heading>
+      <Subheading className="text-agrey">
+        Find out your personality type via the 16 Personalities Website
+      </Subheading>
+      <Link
+        href={"https://www.16personalities.com/free-personality-test"}
+        target="blank"
+      >
+        <Image
+          src={sixteen}
+          className="m-auto p-2"
+          width={1200}
+          height={1200}
+          alt="Sixteen Personalities Website"
+        ></Image>
+      </Link>
+      <Paragraph>
+        Click on the image above to be redirected to the 16 personalities
+        Website. Run through the test and take note of your personality type
+        code (just the first 4 letters). Select this code from the dropdown menu
+        below to discover music based on this personality type. You can learn
+        more about different personality types{" "}
+        <Link
+          href={"https://www.16personalities.com/personality-types"}
+          target="blank"
+          style={{ textDecoration: "underline" }}
+        >
+          here.
+        </Link>
+      </Paragraph>
+      <div className="flex m-2 p-2">
+        <Dropdown>
+          <DropdownTrigger>
+            <Button variant="bordered" className="text-awhite m-auto text-xl">
+              Select Personality Type
+            </Button>
+          </DropdownTrigger>
+          <DropdownMenu aria-label="Static Actions">
+            <DropdownItem key="Architect" className="text-agrey">
+              INTJ - Architect
+            </DropdownItem>
+            <DropdownItem key="Logician" className="text-agrey">
+              INTP - Logician
+            </DropdownItem>
+            <DropdownItem key="Commander" className="text-agrey">
+              ENTJ - Commander
+            </DropdownItem>
+            <DropdownItem key="Debater" className="text-agrey">
+              ENTP - Debater
+            </DropdownItem>
+            <DropdownItem key="Advocate" className="text-agrey">
+              INFJ - Advocate
+            </DropdownItem>
+            <DropdownItem key="Mediator" className="text-agrey">
+              INFP - Mediator
+            </DropdownItem>
+            <DropdownItem key="Protagonist" className="text-agrey">
+              ENFJ - Protagonist
+            </DropdownItem>
+            <DropdownItem key="Campaigner" className="text-agrey">
+              ENFP - Campaigner
+            </DropdownItem>
+            <DropdownItem key="Logistician" className="text-agrey">
+              ISTJ - Logistician
+            </DropdownItem>
+            <DropdownItem key="Defender" className="text-agrey">
+              ISFJ - Defender
+            </DropdownItem>
+            <DropdownItem key="Executive" className="text-agrey">
+              ESTJ - Executive
+            </DropdownItem>
+            <DropdownItem key="Consul" className="text-agrey">
+              ESFJ - Consul
+            </DropdownItem>
+            <DropdownItem key="Virtuoso" className="text-agrey">
+              ISTP - Virtuoso
+            </DropdownItem>
+            <DropdownItem key="Adventurer" className="text-agrey">
+              ISFP - Adventurer
+            </DropdownItem>
+            <DropdownItem key="Entrepreneur" className="text-agrey">
+              ESTP - Entrepreneur
+            </DropdownItem>
+            <DropdownItem key="Entertainer" className="text-agrey">
+              ESFP - Entertainer
+            </DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
+      </div>
+    </>
+  );
 }
 
 export default Testpage;

--- a/src/app/test-page/page.tsx
+++ b/src/app/test-page/page.tsx
@@ -71,7 +71,7 @@ function Testpage() {
           here.
         </Link>
       </Paragraph>
-      <div className="flex m-2 p-2">
+      <div className="flex flex-col m-2 p-2">
         <Dropdown>
           <DropdownTrigger>
             <Button variant="bordered" className="text-awhite m-auto text-xl">

--- a/src/db/dal/user.ts
+++ b/src/db/dal/user.ts
@@ -14,14 +14,14 @@ export interface IUser {
  * @param {string} user.email - The email of the user to be created.
  * @returns {Promise<IUser>} The newly created user.
  */
-export async function createUser({ email }: IUser): Promise<IUser> {
+export async function createUser({ email, personality_type }: IUser): Promise<IUser> {
   const insertUserQuery = `
-    INSERT INTO users (email)
-    VALUES (\$1)
+    INSERT INTO users (email, personality_type)
+    VALUES (\$1, \$2)
     RETURNING *
   `;
 
-  return executeSingleResultQuery(insertUserQuery, [email]);
+  return executeSingleResultQuery(insertUserQuery, [email, personality_type]);
 }
 
 /**


### PR DESCRIPTION
This PR melds the pre-existing user creation functionality with a new "Save" button and the personality type dropdown. It also includes some refactoring.

## Screenshots
**Test page:**
![image](https://github.com/JamesRobertSutcliffe/personality-music-recommender/assets/53922624/3ec3cc51-7ba8-422f-b2a0-55aa6886ed7e)

**Personalised homepage:**
![image](https://github.com/JamesRobertSutcliffe/personality-music-recommender/assets/53922624/051a719f-9852-4334-8780-fd1705f10f09)

☝️This currently uses the personality type code, which is stored in the db. 
If we want to display the "name" of the personality type, we would need a data source to pull that info from. (see TODO)

TODO: #65 In an upcoming PR, a thorough refactoring is planned for both the personalised-homepage and test-page. This will handle the extraction and separation of data fetching, rerouting, and authentication from the rendering of the elements.
As part of the refactoring work, a map will be created containing all the personality types code and name. This will allow us to use the personality type info across the whole web app, rather than just the Dropdown.

## Testing
1. Ensure the docker container is running
2. Sign in
3. Select your personality type and save
4. Confirm you have been redirected to Personalised homepage and it displays the selected personality type.