### PR TITLE
Fetch the recommend algorithm's tracks

### DIFF
--- a/src/app/hooks/spotify/spotify_hooks.tsx
+++ b/src/app/hooks/spotify/spotify_hooks.tsx
@@ -12,11 +12,25 @@ export async function fetchArtistAlbum(token: string) {
     return await result.json();
 }
 
-export async function fetchArtistTrack(token: string) {
-    const result = await fetch("https://api.spotify.com/v1/artists/4ePunOqQbOYoQwd1298g3Z/top-tracks?country=es", {
-        method: "GET", headers: { Authorization: `Bearer ${token}` }
+export async function fetchRecommendedTracks(token: string, personalityType: string) {
+    if(!personalityType) return;
+
+    const apiResponse = await fetch(`https://patdel0-personality-music-recommender.hf.space/recommend?mbti_type=${personalityType}&num_of_songs=10`);
+    const trackSuggestions = await apiResponse.json();
+
+    const trackFetchPromises = trackSuggestions.map((suggestion: {track_id: string}) => fetchTrackData(token, suggestion.track_id));
+    const fetchedTracks = await Promise.all(trackFetchPromises);
+
+    return fetchedTracks;
+}
+
+export async function fetchTrackData(token: string, trackId: string) {
+    const result = await fetch(`https://api.spotify.com/v1/tracks/${trackId}`, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` }
     });
-    return await result.json();
+    const data = await result.json();
+    return data;
 }
 
 export async function fetchUserTracks(token: string) {
@@ -31,4 +45,4 @@ export async function fetchUserPlaylists(token: string) {
         method: "GET", headers: { Authorization: `Bearer ${token}` }
     });
     return await result.json();
-} 
+}

--- a/src/app/personalised-homepage/page.js
+++ b/src/app/personalised-homepage/page.js
@@ -10,7 +10,7 @@ import {
   fetchProfile,
   fetchUserPlaylists,
   fetchUserTracks,
-  fetchArtistTrack,
+  fetchRecommendedTracks,
 } from "../hooks/spotify/spotify_hooks";
 import SpotifyPlayer from "react-spotify-web-playback";
 import ItemCard from "../components/personalised-homepage-components/ItemCard";
@@ -56,13 +56,13 @@ function PersonalisedHomepage() {
       );
       setDbUser(user);
 
+      await fetchRecommendedTracks(accessToken, user.personality_type).then(setTracks);
       setProfileLoad(true);
     };
 
     fetchProfileData(accessToken);
     fetchUserTracks(accessToken).then((res) => setUserTopArray(res.items));
     fetchArtistAlbum(accessToken).then((res) => setAlbums(res.items));
-    fetchArtistTrack(accessToken).then((res) => setTracks(res.tracks));
     fetchUserPlaylists(accessToken).then((res) =>
       setPlaylists(res.playlists?.items)
     );
@@ -76,6 +76,7 @@ function PersonalisedHomepage() {
   const userTopTracks = userTopArray?.map((track) => {
     return track.id;
   });
+
   function setTrackId(e) {
     setPlayTrack(e.currentTarget.id);
     setPlayerType("track");


### PR DESCRIPTION
This PR retrieves the suggested tracks from the recommendation system API, fetches the corresponding track details from Spotify, and then displays the tracks.

Closes #59 

## How to Test
1. Ensure the server is up and running
1. Confirm the tracks displayed in "Recommended Songs" match the ones in the GET response:
`https://patdel0-personality-music-recommender.hf.space/recommend?mbti_type=[your-personality-type]&num_of_songs=10`