### PR TITLE
Feature/display recommended albums from algo recommended tracks

### DIFF
--- a/src/app/hooks/spotify/spotify_hooks.tsx
+++ b/src/app/hooks/spotify/spotify_hooks.tsx
@@ -1,3 +1,5 @@
+// Fetch User Profile Data
+
 export async function fetchProfile(token: string) {
     const result = await fetch("https://api.spotify.com/v1/me/", {
         method: "GET", headers: { Authorization: `Bearer ${token}` }
@@ -5,20 +7,23 @@ export async function fetchProfile(token: string) {
     return await result.json();
 }
 
-export async function fetchArtistAlbum(token: string) {
-    const result = await fetch("https://api.spotify.com/v1/artists/4ePunOqQbOYoQwd1298g3Z/albums", {
+// Fetch Users Top Tracks
+
+export async function fetchUserTracks(token: string) {
+    const result = await fetch("https://api.spotify.com/v1/me/top/tracks", {
         method: "GET", headers: { Authorization: `Bearer ${token}` }
     });
     return await result.json();
 }
 
+// Fetch Personality Type Tracks
+
 export async function fetchRecommendedTracks(token: string, personalityType: string) {
-    if(!personalityType) return;
+    if (!personalityType) return;
 
-    const apiResponse = await fetch(`https://patdel0-personality-music-recommender.hf.space/recommend?mbti_type=${personalityType}&num_of_songs=10`);
+    const apiResponse = await fetch(`https://patdel0-personality-music-recommender.hf.space/recommend?mbti_type=${personalityType}&num_of_songs=20`);
     const trackSuggestions = await apiResponse.json();
-
-    const trackFetchPromises = trackSuggestions.map((suggestion: {track_id: string}) => fetchTrackData(token, suggestion.track_id));
+    const trackFetchPromises = trackSuggestions.map((suggestion: { track_id: string }) => fetchTrackData(token, suggestion.track_id));
     const fetchedTracks = await Promise.all(trackFetchPromises);
 
     return fetchedTracks;
@@ -33,11 +38,15 @@ export async function fetchTrackData(token: string, trackId: string) {
     return data;
 }
 
-export async function fetchUserTracks(token: string) {
-    const result = await fetch("https://api.spotify.com/v1/me/top/tracks", {
-        method: "GET", headers: { Authorization: `Bearer ${token}` }
+// Fetch Personality Type Albums
+
+export async function fetchAlbumData(token: string, albumId: string) {
+    const result = await fetch(`https://api.spotify.com/v1/albums?ids=${albumId}`, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` }
     });
-    return await result.json();
+    const data = await result.json();
+    return data;
 }
 
 export async function fetchUserPlaylists(token: string) {

--- a/src/app/personalised-homepage/page.js
+++ b/src/app/personalised-homepage/page.js
@@ -6,11 +6,11 @@ import ItemRowContainer from "../components/personalised-homepage-components/Ite
 import Bg from "../components/personalised-homepage-components/Bg";
 import { useEffect, useState, useContext } from "react";
 import {
-  fetchArtistAlbum,
   fetchProfile,
   fetchUserPlaylists,
   fetchUserTracks,
   fetchRecommendedTracks,
+  fetchAlbumData
 } from "../hooks/spotify/spotify_hooks";
 import SpotifyPlayer from "react-spotify-web-playback";
 import ItemCard from "../components/personalised-homepage-components/ItemCard";
@@ -42,7 +42,7 @@ function PersonalisedHomepage() {
   const [playerType, setPlayerType] = useState("");
   const [playback, setPlayback] = useState(false);
 
-  // Pulls in placeholder data from a couple of areas of Spotify API
+  // Fetches profile info and personalised recommended tracks 
   useEffect(() => {
     const fetchProfileData = async (accessToken) => {
       const profile = await fetchProfile(accessToken);
@@ -60,23 +60,31 @@ function PersonalisedHomepage() {
       setProfileLoad(true);
     };
 
+    //Fetches profile data and personal top tracks
+
     fetchProfileData(accessToken);
     fetchUserTracks(accessToken).then((res) => setUserTopArray(res.items));
-    fetchArtistAlbum(accessToken).then((res) => setAlbums(res.items));
     fetchUserPlaylists(accessToken).then((res) =>
       setPlaylists(res.playlists?.items)
     );
   }, [accessToken]);
 
-  if (dbUser && Object.keys(dbUser).length === 0) return redirect("/test-page");
-  // Below functions play tracks / albums / playlists on click
+  // Display reccomended albums pulled from recommended tracks algo
 
-  // Useful data for ML / backend //
-  // User top tracks is an array of users top played track IDs
+  useEffect(() => {
+    fetchAlbumData(accessToken, String(tracks.map((track) => track.album.id).reverse())).then((res) => setAlbums(res.albums))
+  }, [tracks])
+
+  // redirects user to test page if they have if they have not previously logged in
+
+  if (dbUser && Object.keys(dbUser).length === 0) return redirect("/test-page");
+
+  // Useful data for ML / backend -- User top tracks is an array of users top played track IDs
   const userTopTracks = userTopArray?.map((track) => {
     return track.id;
   });
 
+  // Below functions play tracks / albums / playlists on click
   function setTrackId(e) {
     setPlayTrack(e.currentTarget.id);
     setPlayerType("track");
@@ -95,15 +103,17 @@ function PersonalisedHomepage() {
     setPlayback(true);
   }
 
-  // userPremium function checks whether user product is premium
+  // userPremium function checks whether user product is premium deciding whether or not to display player
   const userPremium = () => {
     return userProduct === "premium";
   };
 
-  // UserProfilePic function checks whether user
+  // setProfilePic function checks whether user has spotify profile image / decides whether to display placeholders
 
   const setProfilePic =
     userImage === undefined ? "https://i.ibb.co/WHfbS7L/logo.png" : userImage;
+
+  console.log(tracks, albums)
 
   return (
     <Bg>


### PR DESCRIPTION
![Screenshot 2023-10-10 213417](https://github.com/JamesRobertSutcliffe/personality-music-recommender/assets/107635428/c130963b-19e6-4886-8718-8948dabe71e5)
Recommended albums should now be pulled in. Commits should explain the process, but essentially I took the album ID from the fetched recommended track objects from the algo. I rendered these albums to page. 

To Test - 

1 - Rendered albums should match artists pulled in in 'Recommended Tracks' section
2 - Album ID's of Recommended Tracks should match albums pulled in. 

Let me know if any queries!