### PR TITLE
Allow users to like songs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,14 @@
         "postcss": "8.4.27",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-icons": "^4.11.0",
         "react-spotify-web-playback": "^0.14.0",
         "tailwindcss": "3.3.3",
         "typescript": "5.1.6"
       },
       "devDependencies": {
         "@jest/types": "^29.6.3",
+        "@testing-library/jest-dom": "^6.1.3",
         "@testing-library/react": "^14.0.0",
         "@types/jest": "^29.5.5",
         "axios": "^1.5.0",
@@ -44,6 +46,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -3677,6 +3685,60 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.3.tgz",
+      "integrity": "sha512-YzpjRHoCBWPzpPNtg6gnhasqtE/5O4qz8WCwDEaxtfnPO6gkaLrnuXusrGSPyhIGPezr1HM7ZH0CFaUTY9PJEQ==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.0",
+        "@babel/runtime": "^7.9.2",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@testing-library/react": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
@@ -5030,6 +5092,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -6612,6 +6680,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7895,6 +7972,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "node_modules/lodash.foreach": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
@@ -8060,6 +8143,15 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -9058,6 +9150,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9180,6 +9280,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -9734,6 +9847,18 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "postcss": "8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^4.11.0",
     "react-spotify-web-playback": "^0.14.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.1.6"
   },
   "devDependencies": {
     "@jest/types": "^29.6.3",
+    "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.5",
     "axios": "^1.5.0",

--- a/src/app/api/helpers.ts
+++ b/src/app/api/helpers.ts
@@ -1,0 +1,24 @@
+function getEmailFromRequest(request: Request): string | null {
+  const url = new URL(request.url);
+  const params = new URLSearchParams(url.search);
+  return params.get("user_email");
+}
+
+async function getBodyFromRequest(request: Request): Promise<any> {
+  return await request.json();
+}
+
+function constructErrorResponse(errorMessage: string, statusCode: number): Response {
+  return new Response(JSON.stringify({ error: errorMessage }), { status: statusCode });
+}
+
+function constructSuccessResponse(successMessage: string, statusCode: number): Response {
+  return new Response(JSON.stringify({ message: successMessage }), { status: statusCode });
+}
+
+export {
+  getEmailFromRequest,
+  getBodyFromRequest,
+  constructErrorResponse,
+  constructSuccessResponse
+};

--- a/src/app/api/liked-song/route.ts
+++ b/src/app/api/liked-song/route.ts
@@ -1,0 +1,41 @@
+import { getLikedSongs, addLikedSong, removeLikedSong } from "../../../db/dal/likedSong";
+
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const params = new URLSearchParams(url.search);
+  const email = params.get("user_email");
+
+  if (!email) {
+    return new Response(JSON.stringify({ error: "email is required" }), {
+      status: 400,
+    });
+  }
+
+  const likedSongs = await getLikedSongs(email);
+
+  return new Response(JSON.stringify( {...likedSongs} ));
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await request.json();
+  const { user_email, track_id } = body;
+
+  const likedSong = await addLikedSong(user_email, track_id);
+
+  return new Response(
+    JSON.stringify({ message: `Track ${track_id} liked succesffully` }),
+    { status: 201 }
+  );
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  const body = await request.json();
+  const { user_email, track_id } = body;
+
+  const removedSong = await removeLikedSong(user_email, track_id);
+
+  return new Response(
+    JSON.stringify({ message: `Track ${body.track_id} deleted succesffully` }),
+    { status: 200 }
+  );
+}

--- a/src/app/api/liked-song/route.ts
+++ b/src/app/api/liked-song/route.ts
@@ -1,41 +1,39 @@
-import { getLikedSongs, addLikedSong, removeLikedSong } from "../../../db/dal/likedSong";
+import {
+  getLikedSongs,
+  addLikedSong,
+  removeLikedSong,
+} from "../../../db/dal/likedSong";
+import {
+  getEmailFromRequest,
+  getBodyFromRequest,
+  constructErrorResponse,
+  constructSuccessResponse,
+} from "../helpers";
 
 export async function GET(request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const params = new URLSearchParams(url.search);
-  const email = params.get("user_email");
+  const email = getEmailFromRequest(request);
 
   if (!email) {
-    return new Response(JSON.stringify({ error: "email is required" }), {
-      status: 400,
-    });
+    return constructErrorResponse("email is required", 400);
   }
 
   const likedSongs = await getLikedSongs(email);
-
-  return new Response(JSON.stringify( {...likedSongs} ));
+  return new Response(JSON.stringify(likedSongs));
 }
 
 export async function POST(request: Request): Promise<Response> {
-  const body = await request.json();
-  const { user_email, track_id } = body;
+  const { user_email, track_id } = await getBodyFromRequest(request);
 
-  const likedSong = await addLikedSong(user_email, track_id);
-
-  return new Response(
-    JSON.stringify({ message: `Track ${track_id} liked succesffully` }),
-    { status: 201 }
-  );
+  await addLikedSong(user_email, track_id);
+  return constructSuccessResponse(`Track ${track_id} liked successfully`, 201);
 }
 
 export async function DELETE(request: Request): Promise<Response> {
-  const body = await request.json();
-  const { user_email, track_id } = body;
+  const { user_email, track_id } = await getBodyFromRequest(request);
 
-  const removedSong = await removeLikedSong(user_email, track_id);
-
-  return new Response(
-    JSON.stringify({ message: `Track ${body.track_id} deleted succesffully` }),
-    { status: 200 }
+  await removeLikedSong(user_email, track_id);
+  return constructSuccessResponse(
+    `Track ${track_id} deleted successfully`,
+    200
   );
 }

--- a/src/app/components/personalised-homepage-components/ItemCard.tsx
+++ b/src/app/components/personalised-homepage-components/ItemCard.tsx
@@ -1,13 +1,13 @@
-'use client'
-import React from 'react';
-import { FaHeart, FaRegHeart } from 'react-icons/fa';
+"use client";
+import React, { useState, useContext, useEffect } from "react";
+import { FaHeart, FaRegHeart } from "react-icons/fa";
 
 interface ICard {
-    children?: any;
-    title: string;
-    img: string;
-    trackID: string;
-    setPlaybackID: (e: React.MouseEvent<HTMLDivElement>) => void;
+  children?: any;
+  title: string;
+  img: string;
+  trackID: string;
+  setPlaybackID: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 function ItemCard({ children, title, img, trackID, setPlaybackID }: ICard) {

--- a/src/app/components/personalised-homepage-components/ItemCard.tsx
+++ b/src/app/components/personalised-homepage-components/ItemCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState, useContext, useEffect } from "react";
 import { FaHeart, FaRegHeart } from "react-icons/fa";
+import { EmailContext } from "../../context/EmailContext";
 
 interface ICard {
   children?: any;
@@ -11,18 +12,61 @@ interface ICard {
 }
 
 function ItemCard({ children, title, img, trackID, setPlaybackID }: ICard) {
+  const [isSongLiked, setIsSongLiked] = useState(false);
+  const { userEmail } = useContext(EmailContext);
 
-    return (
-        <div className="hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-700 delay-50 duration-100 bg-ablack p-5 rounded-lg min-w-[10vw] group p-2 m-2" id={trackID} onClick={setPlaybackID}>
-            <img src={img}
-                className="w-fulls rounded shadow"
-                alt="Personality Homepage Image">
-            </img>
-            <h3 className="text-gray-200 font-bold mt-5 text-center">{title}</h3>
-            <p className="text-gray-400 font-light mt-2 text-xs text-center">{children}</p>
-            <button onClick={() => alert('liked song')}><FaRegHeart data-testid="empty-heart"/></button>
-        </div>
-    )
+  useEffect(() => {
+    const addOrDelete = async () => {
+      if (isSongLiked) {
+        await fetch("/api/liked-song", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ user_email: userEmail, track_id: trackID }),
+        });
+      }
+      if (!isSongLiked) {
+        await fetch("/api/liked-song", {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ user_email: userEmail, track_id: trackID }),
+        });
+      }
+    };
+    addOrDelete();
+  }, [isSongLiked]);
+
+  async function likeSong() {
+    setIsSongLiked(!isSongLiked);
+  }
+
+  return (
+    <div
+      className="hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-700 delay-50 duration-100 bg-ablack p-5 rounded-lg min-w-[10vw] group p-2 m-2"
+      id={trackID}
+      onClick={setPlaybackID}
+    >
+      <img
+        src={img}
+        className="w-fulls rounded shadow"
+        alt="Personality Homepage Image"
+      ></img>
+      <h3 className="text-gray-200 font-bold mt-5 text-center">{title}</h3>
+      <p className="text-gray-400 font-light mt-2 text-xs text-center">
+        {children}
+      </p>
+      <button onClick={likeSong} data-testid="like-button">
+        {isSongLiked ? (
+          <FaHeart data-testid="filled-heart" />
+        ) : (
+          <FaRegHeart data-testid="empty-heart" />
+        )}
+      </button>
+    </div>
+  );
 }
 
 export default ItemCard;

--- a/src/app/components/personalised-homepage-components/ItemCard.tsx
+++ b/src/app/components/personalised-homepage-components/ItemCard.tsx
@@ -1,4 +1,6 @@
 'use client'
+import React from 'react';
+import { FaHeart, FaRegHeart } from 'react-icons/fa';
 
 interface ICard {
     children?: any;
@@ -18,6 +20,7 @@ function ItemCard({ children, title, img, trackID, setPlaybackID }: ICard) {
             </img>
             <h3 className="text-gray-200 font-bold mt-5 text-center">{title}</h3>
             <p className="text-gray-400 font-light mt-2 text-xs text-center">{children}</p>
+            <button onClick={() => alert('liked song')}><FaRegHeart data-testid="empty-heart"/></button>
         </div>
     )
 }

--- a/src/app/components/personalised-homepage-components/ItemCard.tsx
+++ b/src/app/components/personalised-homepage-components/ItemCard.tsx
@@ -2,6 +2,10 @@
 import React, { useState, useContext, useEffect } from "react";
 import { FaHeart, FaRegHeart } from "react-icons/fa";
 import { EmailContext } from "../../context/EmailContext";
+import {
+  fetchLikedSongsForUser,
+  toggleLikedSong,
+} from "../../utils/likedSongsHelpers";
 
 interface ICard {
   children?: any;
@@ -16,30 +20,16 @@ function ItemCard({ children, title, img, trackID, setPlaybackID }: ICard) {
   const { userEmail } = useContext(EmailContext);
 
   useEffect(() => {
-    const addOrDelete = async () => {
-      if (isSongLiked) {
-        await fetch("/api/liked-song", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ user_email: userEmail, track_id: trackID }),
-        });
-      }
-      if (!isSongLiked) {
-        await fetch("/api/liked-song", {
-          method: "DELETE",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ user_email: userEmail, track_id: trackID }),
-        });
-      }
-    };
-    addOrDelete();
-  }, [isSongLiked]);
+    async function checkIfSongIsLiked() {
+      const isLiked = await fetchLikedSongsForUser(userEmail as string, trackID);
+      setIsSongLiked(isLiked);
+    }
 
-  async function likeSong() {
+    checkIfSongIsLiked();
+  }, [userEmail, trackID]);
+
+  async function handleLikeSong() {
+    await toggleLikedSong(userEmail as string, trackID, isSongLiked);
     setIsSongLiked(!isSongLiked);
   }
 
@@ -52,18 +42,14 @@ function ItemCard({ children, title, img, trackID, setPlaybackID }: ICard) {
       <img
         src={img}
         className="w-fulls rounded shadow"
-        alt="Personality Homepage Image"
+        alt="Song Cover Image"
       ></img>
       <h3 className="text-gray-200 font-bold mt-5 text-center">{title}</h3>
       <p className="text-gray-400 font-light mt-2 text-xs text-center">
         {children}
       </p>
-      <button onClick={likeSong} data-testid="like-button">
-        {isSongLiked ? (
-          <FaHeart data-testid="filled-heart" />
-        ) : (
-          <FaRegHeart data-testid="empty-heart" />
-        )}
+      <button onClick={handleLikeSong} data-testid="like-button">
+        {isSongLiked ? <FaHeart /> : <FaRegHeart />}
       </button>
     </div>
   );

--- a/src/app/utils/likedSongsHelpers.ts
+++ b/src/app/utils/likedSongsHelpers.ts
@@ -1,0 +1,22 @@
+async function fetchLikedSongsForUser(userEmail: string, trackID: string): Promise<boolean> {
+    const response = await fetch(`/api/liked-song?user_email=${userEmail}`);
+    const data = await response.json();
+    return data.rows.some((song: {track_id: string}) => song.track_id === trackID);
+}
+
+async function toggleLikedSong(userEmail: string, trackID: string, isCurrentlyLiked: boolean): Promise<void> {
+    const method = isCurrentlyLiked ? "DELETE" : "POST";
+
+    await fetch("/api/liked-song", {
+        method: method,
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ user_email: userEmail, track_id: trackID }),
+    });
+}
+
+export {
+    fetchLikedSongsForUser,
+    toggleLikedSong
+};

--- a/src/db/dal/likedSong.ts
+++ b/src/db/dal/likedSong.ts
@@ -4,19 +4,19 @@ import { query } from "../db";
 /**
  * Adds a song to a user's liked_songs.
  *
- * @param userId - The user's ID.
- * @param songId - The song's ID.
+ * @param userEmail - The user's email.
+ * @param trackId - The song's ID.
  * @returns The favorite record.
  */
-export async function addLikedSong(userId: number, songId: number) {
+export async function addLikedSong(userEmail: string, trackId: string) {
   const insertLikedSongQuery = `
-    INSERT INTO liked_songs (user_id, song_id)
+    INSERT INTO liked_songs (user_email, track_id)
     VALUES(\$1, \$2)
     RETURNING *`;
 
   const favorite = await executeSingleResultQuery(insertLikedSongQuery, [
-    userId,
-    songId,
+    userEmail,
+    trackId,
   ]);
   return favorite;
 }
@@ -24,36 +24,36 @@ export async function addLikedSong(userId: number, songId: number) {
 /**
  * Retrieves a user's favorite songs.
  *
- * @param userId - The user's ID.
+ * @param userEmail - The user's email.
  * @returns A list of favorite songs.
  */
-export async function getLikedSongs(userId: number) {
+export async function getLikedSongs(userEmail: string) {
   const getUserLikedSongsQuery = `
     SELECT * FROM liked_songs
-    WHERE user_id = \$1
+    WHERE user_email = \$1
   `;
 
-  const userLikedSongs = query(getUserLikedSongsQuery, [userId]);
+  const userLikedSongs = query(getUserLikedSongsQuery, [userEmail]);
   return userLikedSongs;
 }
 
 /**
  * Removes a liked song from a user's liked_songs.
  *
- * @param userId - The user's ID.
- * @param songId - The song's ID to be removed.
+ * @param userEmail - The user's email.
+ * @param trackId - The song's ID to be removed.
  * @returns The removed song's ID.
  */
-export async function removeLikedSong(userId: number, songId: number) {
+export async function removeLikedSong(userEmail: string, trackId: string) {
   const removeLikedSongQuery = `
     DELETE FROM liked_songs
-    WHERE user_id = \$1 AND song_id = \$2
-    RETURNING song_id
+    WHERE user_email = \$1 AND track_id = \$2
+    RETURNING track_id
 `;
 
   const removedSongId = await executeSingleResultQuery(removeLikedSongQuery, [
-    userId,
-    songId,
+    userEmail,
+    trackId,
   ]);
   return removedSongId;
 }

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -12,9 +12,9 @@ CREATE TABLE IF NOT EXISTS users (
 );
 
 CREATE TABLE IF NOT EXISTS liked_songs(
-  user_id INT REFERENCES users(id),
-  song_id INT,
-  PRIMARY KEY (user_id, song_id)
+  user_email VARCHAR(255),
+  track_id VARCHAR(255),
+  PRIMARY KEY (user_email, track_id)
 );
 
 CREATE TABLE IF NOT EXISTS recommendations (

--- a/tests/app/api/liked-song/route.spec.ts
+++ b/tests/app/api/liked-song/route.spec.ts
@@ -1,0 +1,85 @@
+import { GET, POST, DELETE } from "../../../../src/app/api/liked-song/route";
+import { addLikedSong, getLikedSongs } from "../../../../src/db/dal/likedSong";
+import { createMockUser } from "../../../../tests/db/dal/user.spec";
+import { query } from "../../../../src/db/db";
+
+describe("Liked Songs API", () => {
+  beforeEach(
+    async () => await query("DELETE FROM liked_songs WHERE track_id='asdf'")
+  );
+
+  describe("GET Function", () => {
+    it("should return 400 if no email is provided", async () => {
+      const request = { url: "http://localhost" };
+      const result = await GET(request as any);
+
+      expect(result.status).toBe(400);
+    });
+
+    it("should return liked songs list if email exists", async () => {
+      const mockUser = await createMockUser();
+      const request = { url: `http://localhost/api/liked-songs?user_email=${mockUser.email}` };
+
+      const trackId = "asdf";
+      const likedSong = await addLikedSong(mockUser.email as string, trackId);
+
+      const result = await GET(request as any);
+      const data = JSON.parse(await result.text());
+
+      expect(data.rowCount).toBe(1);
+      expect(data.rows[0]).toMatchObject({
+        user_email: mockUser.email,
+        track_id: "asdf",
+      });
+    });
+  });
+
+  describe("POST Function", () => {
+    it("should add a new track to liked_songs", async () => {
+      const newUser = await createMockUser();
+      const request = {
+        json: async () => ({
+          user_email: newUser.email,
+          track_id: "asdf",
+        }),
+      };
+
+      const previousLikedSongs = await getLikedSongs(newUser.email as string)
+      const previousSongCount = previousLikedSongs.rowCount;
+
+      const result = await POST(request as any);
+      expect(result.status).toBe(201)
+
+      const currentLikedSongs = await getLikedSongs(newUser.email as string)
+      const currentSongCount = currentLikedSongs.rowCount;
+      expect(currentSongCount).toBe(previousSongCount + 1);
+
+    });
+  });
+
+  describe("DELETE function", () => {
+    it('deletes the liked_song pair from the db',async () => {
+      const newUser = await createMockUser();
+      const request = {
+        json: async () => ({
+          user_email: newUser.email,
+          track_id: "asdf",
+        }),
+      };
+
+      const POSTresult = await POST(request as any);
+      expect(POSTresult.status).toBe(201)
+
+      const previousLikedSongs = await getLikedSongs(newUser.email as string)
+      const previousSongCount = previousLikedSongs.rowCount;
+      expect(previousSongCount).toBe(1);
+
+      const DELETEresult = await DELETE(request as any);
+      expect(DELETEresult.status).toBe(200)
+
+      const currentLikedSongs = await getLikedSongs(newUser.email as string)
+      const currentSongCount = currentLikedSongs.rowCount;
+      expect(currentSongCount).toBe(0);
+    })
+  })
+});

--- a/tests/app/api/liked-song/route.spec.ts
+++ b/tests/app/api/liked-song/route.spec.ts
@@ -21,7 +21,7 @@ describe("Liked Songs API", () => {
       const request = { url: `http://localhost/api/liked-songs?user_email=${mockUser.email}` };
 
       const trackId = "asdf";
-      const likedSong = await addLikedSong(mockUser.email as string, trackId);
+      await addLikedSong(mockUser.email as string, trackId);
 
       const result = await GET(request as any);
       const data = JSON.parse(await result.text());
@@ -45,15 +45,12 @@ describe("Liked Songs API", () => {
       };
 
       const previousLikedSongs = await getLikedSongs(newUser.email as string)
-      const previousSongCount = previousLikedSongs.rowCount;
 
       const result = await POST(request as any);
       expect(result.status).toBe(201)
 
       const currentLikedSongs = await getLikedSongs(newUser.email as string)
-      const currentSongCount = currentLikedSongs.rowCount;
-      expect(currentSongCount).toBe(previousSongCount + 1);
-
+      expect(currentLikedSongs.rowCount).toBe(previousLikedSongs.rowCount + 1);
     });
   });
 
@@ -71,15 +68,13 @@ describe("Liked Songs API", () => {
       expect(POSTresult.status).toBe(201)
 
       const previousLikedSongs = await getLikedSongs(newUser.email as string)
-      const previousSongCount = previousLikedSongs.rowCount;
-      expect(previousSongCount).toBe(1);
+      expect(previousLikedSongs.rowCount).toBe(1);
 
       const DELETEresult = await DELETE(request as any);
       expect(DELETEresult.status).toBe(200)
 
       const currentLikedSongs = await getLikedSongs(newUser.email as string)
-      const currentSongCount = currentLikedSongs.rowCount;
-      expect(currentSongCount).toBe(0);
+      expect(currentLikedSongs.rowCount).toBe(0);
     })
   })
 });

--- a/tests/app/api/user/route.spec.ts
+++ b/tests/app/api/user/route.spec.ts
@@ -17,7 +17,7 @@ describe("GET Function", () => {
     const result = await GET(request as any);
     const data = JSON.parse(await result.text());
 
-    expect(data.dbUser.email).toBe(mockUser.email);
+    expect(data.email).toBe(mockUser.email);
   });
 });
 

--- a/tests/db/dal/likedSong.spec.ts
+++ b/tests/db/dal/likedSong.spec.ts
@@ -7,19 +7,21 @@ import {
 } from "../../../src/db/dal/likedSong";
 
 describe("Liked songs table", () => {
-  let userId: number;
+  let userEmail: string;
 
   beforeEach(async () => {
+    await query("DELETE FROM liked_songs");
     const newUser = await createMockUser();
-    userId = newUser.id as number;
+    userEmail = newUser.email as string;
   });
-
+  afterEach(async () => {
+  })
   describe("addLikedSong()", () => {
     it("adds a new liked song to a user", async () => {
       const previousLikedSongs = await query("SELECT * FROM liked_songs");
 
-      const songId = 1;
-      await addLikedSong(userId, songId);
+      const songId = 'asdf';
+      await addLikedSong(userEmail, songId);
 
       const updatedLikedSongs = await query("SELECT * FROM liked_songs");
 
@@ -29,33 +31,31 @@ describe("Liked songs table", () => {
 
   describe("getLikedSongs()", () => {
     beforeEach(async () => {
-      await addLikedSong(userId, 1);
-      await addLikedSong(userId, 2);
+      await addLikedSong(userEmail, 'asdf');
     });
 
     it("returns the liked songs associated with the user id", async () => {
-      const userLikedSongs = await getLikedSongs(userId);
+      const userLikedSongs = await getLikedSongs(userEmail);
 
-      expect(userLikedSongs.rowCount).toBe(2);
-      expect(userLikedSongs.rows[0]).toMatchObject({ song_id: 1 });
-      expect(userLikedSongs.rows[1]).toMatchObject({ song_id: 2 });
+      expect(userLikedSongs.rowCount).toBe(1);
+      expect(userLikedSongs.rows[0]).toMatchObject({ track_id: 'asdf', user_email: userEmail });
     });
   });
 
   describe("removeLikedSong()", () => {
     beforeEach(async () => {
-      const songId = 2;
-      await addLikedSong(userId, songId);
+      const songId = 'asdf';
+      await addLikedSong(userEmail, songId);
     });
 
     it("removes a liked song", async () => {
-      let likedSongs = await getLikedSongs(userId);
+      let likedSongs = await getLikedSongs(userEmail);
       expect(likedSongs.rowCount).toBe(1);
 
-      const songId = 2;
-      await removeLikedSong(userId, songId);
+      const songId = 'asdf';
+      await removeLikedSong(userEmail, songId);
 
-      likedSongs = await getLikedSongs(userId);
+      likedSongs = await getLikedSongs(userEmail);
       expect(likedSongs.rowCount).toBe(0);
     });
   });


### PR DESCRIPTION
This PR ensures users have a way of liking a specific track via the Like button, triggering an event to add or remove the track from the DB accordingly.

In addition to the inclusion of the new feature, it also renames and cleans up code related to the `liked_songs` table to standardise naming conventions used across the app.

Relates #40 

![image](https://github.com/JamesRobertSutcliffe/personality-music-recommender/assets/53922624/fd81e8bc-48c6-43c8-98be-6302d000febb)

Personal TODO: Attempt to clean up commit history once approved

## How to Test
1. `./scripts/reset_docker.sh
2. `./scripts/server.sh`
1. Login and access the Personalised Homepage
2. "Like" a track by clicking on a couple of heart icons
3. Confirm they are "filled in"
4. Refresh the page
5. Ensure the liked tracks remain as "liked"
6. Once the above is confirmed to work as expected, run the automated tests `npm run test`

